### PR TITLE
[PrivateAccess] Dont use private values of pan object

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -58,12 +58,10 @@ class Flix extends Component {
         null, {dx: this.state.pan.x, dy: this.state.pan.y},
       ]),
 
-      onPanResponderRelease: (e, {vx, vy}) => {
-        this.state.pan.flattenOffset();
-
+      onPanResponderRelease: (e, {dx, vx, vy}) => {
         var direction = vx > 0 ? 1 : -1;
         var velocity = clamp(Math.abs(vx), 3, 5) * direction;
-        if (Math.abs(this.state.pan.x._value) > DecisionThreshold) {
+        if (Math.abs(dx) > DecisionThreshold) {
           Animated.decay(this.state.pan.x, {
             velocity: velocity,
             deceleration: 0.98,

--- a/index.ios.js
+++ b/index.ios.js
@@ -11,6 +11,8 @@ const People = [
   'orange',
 ]
 
+const DecisionThreshold = 120;
+
 class Flix extends Component {
   constructor(props) {
     super(props);
@@ -58,15 +60,10 @@ class Flix extends Component {
 
       onPanResponderRelease: (e, {vx, vy}) => {
         this.state.pan.flattenOffset();
-        var velocity;
 
-        if (vx > 0) {
-          velocity = clamp(vx, 3, 5);
-        } else if (vx < 0) {
-          velocity = clamp(vx * -1, 3, 5) * -1;
-        }
-
-        if (this.state.pan.x._value > 120 || this.state.pan.x._value < -120) {
+        var direction = vx > 0 ? 1 : -1;
+        var velocity = clamp(Math.abs(vx), 3, 5) * direction;
+        if (Math.abs(this.state.pan.x._value) > DecisionThreshold) {
           Animated.decay(this.state.pan.x, {
             velocity: velocity,
             deceleration: 0.98,


### PR DESCRIPTION
`this.state.pan.flattenOffset()` is undocumented from what I can tell, so it was a bit confusing to see this in the code. It's followed up with some private variable accessing (`this.state.pan.x._value`), but I dont think we need this @brentvatne -- we just need the total accumulated distance right? That should be part of the gesture object as dx, so we can just use that. This PR adds the `dx` variable declaration from the gesture object.

This also simplifies some of the velocity clamping logic, but I can revert those changes if you want since it's a bit opinionated.

Anyways great demo overall though!
