### PR TITLE
fix bug:

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -22,6 +22,7 @@ class Flix extends Component {
       enter: new Animated.Value(0.5),
       person: People[0],
     }
+    this._resetState = this._resetState.bind(this);
   }
 
   _goToNextPerson() {


### PR DESCRIPTION
when Animated.decay().start() call the function "this._resetState",
the variable `this` may not point to component itself.
So, I think should add code `this._resetState = this._resetState.bind(this)`
English is not my mother tongue, forgive my English is not good